### PR TITLE
correction to the computation of declination

### DIFF
--- a/eot.py
+++ b/eot.py
@@ -69,16 +69,17 @@ def obl_gen(p, axis_norm_rads, peri_day, orb_per, day_nums):
 #   day_nums        numpy array of day numbers
 # outputs:
 #   decs_degs       declination list in degrees
-def dec_gen(e, axis_norm_degs, orb_per, day_nums):
+def dec_gen(e, axis_norm_degs, orb_per, day_nums, p_degs):
     dec_degs = []
     sin_axis_norm = sin(radians(axis_norm_degs))
     ratio360 = 360 / orb_per
     ratio_pi_e = (360 / pi) * e
+    days_btw_peri_solst = p_degs / ratio360
 
     for d in day_nums:
         d_offset = d - 1
         dec_degs.append(-(asin(sin_axis_norm *
-                               cos(radians(ratio360*(d_offset+10) +
+                               cos(radians(ratio360*(d_offset+(days_btw_peri_solst-2)) +
                                    ratio_pi_e*sin(radians(ratio360*(d_offset-2))))))*360/(2*pi)))
     return dec_degs
 
@@ -95,6 +96,6 @@ def dec_gen(e, axis_norm_degs, orb_per, day_nums):
 #   eot_mins        equation of time list in minutes
 #   dec_degs        declination list in degrees
 def analemma_gen(e, p_degs, axis_norm_degs, peri_day, orb_per, day_nums):
-    dec_degs = dec_gen(e, axis_norm_degs, orb_per, day_nums)
+    dec_degs = dec_gen(e, axis_norm_degs, orb_per, day_nums, p_degs)
     eot_mins = eot_gen(e, p_degs, axis_norm_degs, peri_day, orb_per, day_nums)
     return eot_mins, dec_degs

--- a/eot.py
+++ b/eot.py
@@ -67,6 +67,7 @@ def obl_gen(p, axis_norm_rads, peri_day, orb_per, day_nums):
 #   axis_norm_degs  angle between the earth's axis and the norm of the orbit in degrees (23.4367)
 #   orb_per         earth orbital period (365.25696)
 #   day_nums        numpy array of day numbers
+#   p_degs          projection of the axis of the earth onto the plane of the orbit in degrees
 # outputs:
 #   decs_degs       declination list in degrees
 def dec_gen(e, axis_norm_degs, orb_per, day_nums, p_degs):


### PR DESCRIPTION
I know this project hasn't been touched for two years, but I think it has value so I looked into this.
There is a problem with how declination (angle) is computed. The declination of the sun on a given day changes depending on the angular distance between the perihelion and the winter solstice (a quantity called `p_degs` in this project). For this reason the formula you take from wikipedia needs a little correction (btw, thanks for stating your sources, this is always a very good thing to do).
Intuitively, the error is easy to see if you set the eccentricity to 0 and start changing the Solstice/Peri slider. With 0 eccentricity there is no perihelion, so changing the solstice / perihelion angle cannot have an effect on the shape of the analemma.